### PR TITLE
Bump python version to 3.12

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,4 +9,4 @@ termcolor = "==1.1.0"
 [dev-packages]
 
 [requires]
-python_version = "3.7"
+python_version = "3.12"


### PR DESCRIPTION
Python 3.7. is not supported anymore
Bump to the latest supported version